### PR TITLE
Router and controller

### DIFF
--- a/handlers/handlers_setup_test.go
+++ b/handlers/handlers_setup_test.go
@@ -40,10 +40,10 @@ func router() *gin.Engine {
 		HandleGetVendorById(c, id)
 	})
 	// publicRoutes.POST("/vendors", HandleCreateVendor)
-	// publicRoutes.PATCH("/vendors/:id", func(c *gin.Context) {
-	// 	id, _ := strconv.Atoi(c.Param("id"))
-	// 	HandleUpdateVendor(c, id)
-	// })
+	publicRoutes.PATCH("/vendors/:id", func(c *gin.Context) {
+		id, _ := strconv.Atoi(c.Param("id"))
+		HandleUpdateVendor(c, id)
+	})
 	// // Market Vendors
 	// publicRoutes.GET("/markets/:id/vendors", func(c *gin.Context) {
 	// 	id, _ := strconv.Atoi(c.Param("id"))

--- a/handlers/vendors_handler.go
+++ b/handlers/vendors_handler.go
@@ -4,6 +4,8 @@ import (
 	"example.com/mod/models"
 	"net/http"
 	"github.com/gin-gonic/gin"
+	"io"
+	"encoding/json"
 )
 
 func HandleGetAllVendors(context *gin.Context) {
@@ -22,7 +24,30 @@ func HandleGetVendorById(context *gin.Context, id int) {
 
 	if err != nil {
 		context.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
 	}
 
 	context.JSON(http.StatusOK, gin.H{"data": vendor})
+}
+
+func HandleUpdateVendor(context *gin.Context, id int) {
+	var vendorUpdates models.Vendor
+
+	body, err := io.ReadAll(context.Request.Body)
+
+	if err != nil {
+		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	json.Unmarshal([]byte(body), &vendorUpdates)
+
+	vendor, err := models.UpdateVendor(id, vendorUpdates)
+
+	if err != nil {
+		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	context.JSON(http.StatusAccepted, gin.H{"data": vendor})
 }

--- a/handlers/vendors_handler_test.go
+++ b/handlers/vendors_handler_test.go
@@ -68,6 +68,8 @@ func TestUpdateVendor(t *testing.T) {
 	assert.Equal(t, true, exists)
 
 	updatedVendor := response["data"]
+	Vendor1, _ = models.GetVendorById(Vendor1.Id)
+	
 	assert.Equal(t, float64(Vendor1.Id), updatedVendor["id"])
 	assert.Equal(t, Vendor1.ContactName, updatedVendor["contact_name"])
 	assert.Equal(t, Vendor1.ContactPhone, updatedVendor["contact_phone"])

--- a/handlers/vendors_handler_test.go
+++ b/handlers/vendors_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"github.com/stretchr/testify/assert"
 	"fmt"
+	"example.com/mod/models"
 )
 
 func TestGetVendors(t *testing.T) {
@@ -54,5 +55,22 @@ func TestGetVendorById(t *testing.T) {
 	assert.Equal(t, Vendor1.Name, vendor1["name"])
 	assert.Equal(t, Vendor1.Description, vendor1["description"])
 	assert.Equal(t, Vendor1.CreditAccepted, vendor1["credit_accepted"])
-	
+}
+
+func TestUpdateVendor(t *testing.T) {
+	url := fmt.Sprintf("/api/vendors/%d", Vendor1.Id)
+	vendorUpdates := models.Vendor{ContactName: "Updated Name", ContactPhone: "Updated Phone"}
+	writer := makeRequest("PATCH", url, vendorUpdates)
+
+	var response map[string]map[string]any
+	json.Unmarshal(writer.Body.Bytes(), &response)
+	_, exists := response["data"]
+	assert.Equal(t, true, exists)
+
+	updatedVendor := response["data"]
+	assert.Equal(t, float64(Vendor1.Id), updatedVendor["id"])
+	assert.Equal(t, Vendor1.ContactName, updatedVendor["contact_name"])
+	assert.Equal(t, Vendor1.ContactPhone, updatedVendor["contact_phone"])
+	assert.Equal(t, Vendor1.ContactName, "Updated Name")
+	assert.Equal(t, Vendor1.ContactPhone, "Updated Phone")
 }

--- a/router/router.go
+++ b/router/router.go
@@ -31,10 +31,10 @@ func Router() {
 		handlers.HandleGetVendorById(c, id)
 	})
 	// publicRoutes.POST("/vendors", HandleCreateVendor())
-	// publicRoutes.PATCH("/vendors/:id", func(c *gin.Context) {
-	// 	id, _ := strconv.Atoi(c.Param("id"))
-	// 	HandleUpdateVendor()
-	// })
+	publicRoutes.PATCH("/vendors/:id", func(c *gin.Context) {
+		id, _ := strconv.Atoi(c.Param("id"))
+		handlers.HandleUpdateVendor(c, id)
+	})
 	// // Market Vendors
 	// publicRoutes.GET("/markets/:id/vendors", func(c *gin.Context) {
 	// 	id, _ := strconv.Atoi(c.Param("id"))


### PR DESCRIPTION
This PR adds testing and functionality for Patch requests sent via http to the /api/vendors/:id endpoint and allows for updating any vendor in the database with new information. Requests must be sent with the new information in the body of the request, but only needs to include fields that are being updated for the vendor and the vendor id in the uri.